### PR TITLE
Update EIP-7885: Add end-to-end signature verification benchmarks for NTT precompiles

### DIFF
--- a/EIPS/eip-7885.md
+++ b/EIPS/eip-7885.md
@@ -282,6 +282,25 @@ BenchmarkPrecompiledEcrecover/-Gas=3000-4
 
 The benchmarks demonstrate that all NTT precompiles maintain competitive or better throughput compared to existing precompiled contracts like ECRECOVER, processing approximately 52-56 million gas per second. Both implementations (nocgo and cgo) provide efficient support for multiple post-quantum cryptographic schemes including Falcon-512/1024 and ML-DSA/Dilithium, with the liboqs variant offering ~36-38% lower gas costs for NTT operations.
 
+#### End-to-End Signature Verification with Precompiles
+
+Integration testing demonstrates the practical impact of NTT precompiles on full signature verification. Tests were conducted using modified ZKNOX implementations (ETHFALCON and ETHDILITHIUM) against an op-geth client with NTT precompile support.
+
+**Test Environment**: OP-Stack testnet with NTT precompiles enabled.
+
+| Algorithm | Verification Method | Pure Solidity | With Precompile | Gas Saved |
+|-----------|-------------------|---------------|-----------------|-----------|
+| ETHFALCON (Falcon-512) | Direct | 1,800,000 | 479,341 | 1,320,659 (73.4%) |
+| ETHDILITHIUM (ML-DSA) | PKContract-based | 9,746,410 | 7,618,412 | 2,127,998 |
+| ETHDILITHIUM (ML-DSA) | Direct (struct) | 7,874,354 | 5,732,354 | 2,142,000 |
+
+**Key Findings**:
+
+- **ETHFALCON**: Achieves 73.4% gas reduction with NTT precompiles, reducing signature verification cost from 1.8M gas to under 480K gas.
+- **ETHDILITHIUM**: NTT precompiles save over 2.1M gas per signature verification.
+
+These results validate that NTT precompiles significantly reduce gas costs for post-quantum signature verification, making lattice-based cryptography more practical for Ethereum applications.
+
 ## Backwards Compatibility
 
 There are no backward compatibility questions.
@@ -349,7 +368,7 @@ Benchmark data are available in the EIP assets:
 
 - [Python reference implementation](../assets/eip-7885/pythonref)
 
-- [Solidity reference implementation](../assets/eip-7885/solidity)
+- [Solidity reference implementation](../assets/eip-7885/solidity/src/ZKNOX_NTT.sol)
 
 - OP-Geth implementations in the assets of this EIP:
   - [Pure Go (nocgo)](../assets/eip-7885/op-geth/nocgo)


### PR DESCRIPTION
This update adds a new section on End-to-End Signature Verification with Precompiles, based on tests using modified ETHFALCON and ETHDILITHIUM implementations running against an OP-Stack testnet with NTT precompiles enabled.

ETHFALCON (Falcon-512)
  Direct verification: 479k gas
ETHDILITHIUM (ML-DSA)
  PKContract-based: 7.62M gas
  Direct (struct-based): 5.73M gas

All measurements were obtained using the following integration test suite:
https://github.com/yhl125/precompile-test