### PR TITLE
Update EIP-7885: Fix MD049 linter error for mathbb notation

### DIFF
--- a/EIPS/eip-7885.md
+++ b/EIPS/eip-7885.md
@@ -41,12 +41,12 @@ We introduce *four* separate precompiles to perform the following operations:
 ### Field parameters
 
 The NTT_FW and NTT_INV are fully defined by the following set of parameters:
-Let $R$ be a cyclotomic ring of the form $R=\mathbb{F}_q[X]/(X^n+1)$. In these notations,
+Let $R$ be a cyclotomic ring of the form $R=\mathbb F_q[X]/(X^n+1)$. In these notations,
 
 - $n$ is the degree and is a power of 2,
-- $\mathbb{F}_q$ is the prime field where $q \equiv 1 \mod 2n$,
-- $\omega$ is a $n$-th root of unity in $\mathbb{F}_q$,
-- $\psi$ is a $2n$-th root of unity in $\mathbb{F}_q$.
+- $\mathbb F_q$ is the prime field where $q \equiv 1 \mod 2n$,
+- $\omega$ is a $n$-th root of unity in $\mathbb F_q$,
+- $\psi$ is a $2n$-th root of unity in $\mathbb F_q$.
 
 Any element $a \in R$ is a polynomial of degree at most $n-1$ with integer coefficients, written
 as $a=\sum_{i=0}^{n-1} a_iX^i$
@@ -55,7 +55,7 @@ as $a=\sum_{i=0}^{n-1} a_iX^i$
 
 The NTT transformation is described by the following algorithm.
 
-**Input:** A vector $a = (a[0], a[1], \dots, a[n-1]) \in \mathbb{F}_q^n$ in standard order, where $q$ is a prime such that $q \equiv 1 \mod 2n$ and $n$ is a power of two, and a precomputed table $\Psi_\text{rev} \in \mathbb{Z}_q^n$ storing powers of $\psi$ in bit-reversed order.
+**Input:** A vector $a = (a[0], a[1], \dots, a[n-1]) \in \mathbb F_q^n$ in standard order, where $q$ is a prime such that $q \equiv 1 \mod 2n$ and $n$ is a power of two, and a precomputed table $\Psi_\text{rev} \in \mathbb{Z}_q^n$ storing powers of $\psi$ in bit-reversed order.
 
 **Output:** $a \leftarrow \text{NTT\_FW}(a)$ in bit-reversed order.
 
@@ -82,7 +82,7 @@ return a
 
 The Inverse NTT is described by the following algorithm.
 
-**Input:** A vector $a = (a[0], a[1], \dots, a[n-1]) \in \mathbb{F}_q^n$ in bit-reversed order, where $q$ is a prime such that $q \equiv 1 \mod 2n$ and $n$ is a power of two, and a precomputed table $\Psi^{-1}_\text{rev} \in \mathbb{F}_q^n$ storing powers of $\psi^{-1}$ in bit-reversed order.
+**Input:** A vector $a = (a[0], a[1], \dots, a[n-1]) \in \mathbb F_q^n$ in bit-reversed order, where $q$ is a prime such that $q \equiv 1 \mod 2n$ and $n$ is a power of two, and a precomputed table $\Psi^{-1}_\text{rev} \in \mathbb F_q^n$ storing powers of $\psi^{-1}$ in bit-reversed order.
 
 **Output:** $a \leftarrow \text{NTT\_INV}(a)$ in standard order.
 
@@ -114,7 +114,7 @@ return a
 
 The NTT_VECMULMOD is functions similarly to SIMD, but operates with larger input and output sizes.
 
-**Input:** Two vectors $a = (a[0], a[1], \dots, a[n-1]), b=(b[0], b[1], \dots, b[n-1]) \in \mathbb{F}_q^n$ where $n$ and $q$ are defined above.
+**Input:** Two vectors $a = (a[0], a[1], \dots, a[n-1]), b=(b[0], b[1], \dots, b[n-1]) \in \mathbb F_q^n$ where $n$ and $q$ are defined above.
 
 **Output:** The element-wise product $(a[0]\cdot b[0] \mod q, a[1]\cdot b[1]\mod q, \dots, a[n-1]\cdot b[n-1] \mod q)$.
 
@@ -124,7 +124,7 @@ The NTT_VECMULMOD is functions similarly to SIMD, but operates with larger input
 
 The NTT_VECMULMOD is similar to SIMD in the functioning, but operates with larger sizes in input and output.
 
-**Input:** Two vectors $a = (a[0], a[1], \dots, a[n-1]), b=(b[0], b[1], \dots, b[n-1]) \in \mathbb{F}_q^n$ where $n$ and $q$ are defined above.
+**Input:** Two vectors $a = (a[0], a[1], \dots, a[n-1]), b=(b[0], b[1], \dots, b[n-1]) \in \mathbb F_q^n$ where $n$ and $q$ are defined above.
 
 **Output:** The element-wise addition $(a[0]+ b[0] \mod q, a[1]+ b[1]\mod q, \dots, a[n-1]+ b[n-1] \mod q)$.
 


### PR DESCRIPTION
fix MD049/emphasis-style Emphasis style should be consistent [Expected: asterisk; Actual: underscore]